### PR TITLE
main file, easier for webpack/angular builds supporting es6 import/export syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./src/angular-environment');
+module.exports = 'environment';

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "angular-environment",
   "version": "1.0.3",
   "description": "AngujarJS Environment Plugin",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/juanpablob/angular-environment.git"


### PR DESCRIPTION
Hello, with this pull request applied, you can easly do es6 import syntax like this:
it is done in similar fashion to 'angular-ui-bootstrap'

// angular and angular dependencies
import angular from 'angular';
import uirouter from 'angular-ui-router';
import uiBootstrap from 'angular-ui-bootstrap';
import angularEnvironment from 'angular-environment';

// own modules
import root from './root/root.module';
import home from './home/home.module';

// configuration
angular
  .module('app', [
    // vendor module dependencies
    uirouter,
    uiBootstrap,
    angularEnvironment,

```
// own dependencies
root,
home
```

  ])
  .config( /_@ngInject_/ function ($urlRouterProvider, $stateProvider) {
    $urlRouterProvider.otherwise('/home');
  });
