### PR TITLE
Fix domain check

### DIFF
--- a/src/angular-environment.js
+++ b/src/angular-environment.js
@@ -87,7 +87,7 @@ angular.module('environment', []).
 
 			angular.forEach(this.data.domains, function(v, k) {
 				angular.forEach(v, function(v) {
-					if (location.match('//' + v)) {
+					if (location.match('/' + v + '$/')) {
 						self.environment = k;
 					}
 				});

--- a/src/angular-environment.js
+++ b/src/angular-environment.js
@@ -88,7 +88,7 @@ angular.module('environment', []).
 			angular.forEach(this.data.domains, function(v, k) {
 				angular.forEach(v, function(v) {
 					if (location.match('/' + v + '$/')) {
-						self.environment = k;
+						return self.environment = k;
 					}
 				});
 			});


### PR DESCRIPTION
Right now the domain check function does not properly detect the domain.
In my particular case I was using:
admin.mc.dev - development
admin.mc.dex - integration
admin.mc.de  - production

The admin.mc.de is always the one that the checker returns, it also assigns *.dev and then moves to the *.de because it's missing a return statement.
