### PR TITLE
Match regex match beginning of location.href only

### DIFF
--- a/src/angular-environment.js
+++ b/src/angular-environment.js
@@ -87,7 +87,7 @@ angular.module('environment', []).
 
 			angular.forEach(this.data.domains, function(v, k) {
 				angular.forEach(v, function(v) {
-					if (location.match('//' + v)) {
+					if (location.match(new RegExp("^http(s)?:\/\/" + v))) {
 						self.environment = k;
 					}
 				});


### PR DESCRIPTION
The match string will find any occurrences of a string in the location.href. There a possibility a different environment is present later in the string and that will be matched incorrectly.
